### PR TITLE
Bump up Presto version to 0.195

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ run:
 
 down:
 	docker-compose down
+
+cli:
+	docker exec -it coordinator /usr/bin/presto

--- a/presto-base/Dockerfile
+++ b/presto-base/Dockerfile
@@ -5,7 +5,7 @@
 FROM ubuntu:14.04
 MAINTAINER lewuathe
 
-ENV PRESTO_VERSION=0.192-SNAPSHOT
+ENV PRESTO_VERSION=0.195
 ENV PRESTO_HOME=/usr/local/presto
 ENV BASE_URL=https://repo1.maven.org/maven2/com/facebook/presto
 
@@ -25,9 +25,12 @@ ENV JAVA_HOME /usr/java/default
 ENV PATH $PATH:$JAVA_HOME/bin
 
 WORKDIR /usr/local
-ADD presto-server-${PRESTO_VERSION}.tar.gz /usr/local
-# RUN wget ${BASE_URL}/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz
+# ADD presto-server-${PRESTO_VERSION}.tar.gz /usr/local
+RUN wget ${BASE_URL}/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz && tar zxvf presto-server-${PRESTO_VERSION}.tar.gz
 RUN ln -s /usr/local/presto-server-${PRESTO_VERSION} $PRESTO_HOME
+
+RUN wget ${BASE_URL}/presto-cli/${PRESTO_VERSION}/presto-cli-${PRESTO_VERSION}-executable.jar -O /usr/bin/presto
+RUN chmod +x /usr/bin/presto 
 
 # Create data dir
 RUN mkdir -p $PRESTO_HOME/data

--- a/presto-coordinator/etc/catalog/tpcds.properties
+++ b/presto-coordinator/etc/catalog/tpcds.properties
@@ -1,0 +1,1 @@
+connector.name=tpcds

--- a/presto-coordinator/etc/catalog/tpch.properties
+++ b/presto-coordinator/etc/catalog/tpch.properties
@@ -1,0 +1,1 @@
+connector.name=tpch

--- a/presto-worker/etc/catalog/tpcds.properties
+++ b/presto-worker/etc/catalog/tpcds.properties
@@ -1,0 +1,1 @@
+connector.name=tpcds

--- a/presto-worker/etc/catalog/tpch.properties
+++ b/presto-worker/etc/catalog/tpch.properties
@@ -1,0 +1,1 @@
+connector.name=tpch


### PR DESCRIPTION
This PR includes:
- Update Presto version to 0.195
- Add TPCH and TPCDS catalogs
- Add Presto CLI to presto-base

Please see the each commit. Thanks!