### PR TITLE
Build Docker images automatically with make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ Temporary Items
 .apdisk
 
 *.tar.gz
+presto-base/presto

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 all:
+	git submodule init
+	git submodule update
+	cd presto && ./mvnw clean install -DskipTests  && cd -
+	cp presto/presto-server/target/presto-server-*.tar.gz presto-base/ && cp presto/presto-cli/target/presto-*-executable.jar presto-base/presto
 	docker build -t lewuathe/presto-base:latest presto-base
 	docker build -t lewuathe/presto-coordinator:latest presto-coordinator
 	docker build -t lewuathe/presto-worker:latest presto-worker
@@ -8,7 +12,13 @@ all:
 
 run:
 	docker-compose up -d
-	echo "Please check http://localhost:8080"
+	@echo "Please check http://localhost:8080"
 
 down:
 	docker-compose down
+
+cli:
+	docker exec -it coordinator /usr/bin/presto
+
+clean:
+	rm -rf presto-base/presto*

--- a/presto-base/Dockerfile
+++ b/presto-base/Dockerfile
@@ -29,6 +29,10 @@ ADD presto-server-${PRESTO_VERSION}.tar.gz /usr/local
 # RUN wget ${BASE_URL}/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz
 RUN ln -s /usr/local/presto-server-${PRESTO_VERSION} $PRESTO_HOME
 
+# CLI
+ADD presto /usr/bin/ 
+RUN chmod +x /usr/bin/presto
+
 # Create data dir
 RUN mkdir -p $PRESTO_HOME/data
 VOLUME ["$PRESTO_HOME/etc", "$PRESTO_HOME/data"]


### PR DESCRIPTION
I've revised the patch:
- Build Presto server and cli with make
- Add 'cli' target to Makefile

Simply run this command for testing:
```
make clean all && make run && make cli
```
