### PR TITLE
Fixing image version in docker-compose.yml and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,9 @@ push: build
 	docker push lewuathe/presto-worker:$(PRESTO_VERSION)
 
 run:
-	docker-compose up -d
+	
+	PRESTO_VERSION=$(PRESTO_VERSION) docker-compose up -d
 	echo "Please check http://localhost:8080"
 
 down:
-	docker-compose down
+	PRESTO_VERSION=$(PRESTO_VERSION) docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	docker build --build-arg VERSION=${PRESTO_VERSION} -t lewuathe/presto-base:${PRESTO_VERSION} presto-base
 	docker build --build-arg VERSION=${PRESTO_VERSION} -t lewuathe/presto-coordinator:${PRESTO_VERSION} presto-coordinator
 	docker build --build-arg VERSION=${PRESTO_VERSION} -t lewuathe/presto-worker:${PRESTO_VERSION} presto-worker
-	docker-compose build
+	PRESTO_VERSION=$(PRESTO_VERSION) docker-compose build
 
 local:
 	docker build --build-arg VERSION=${PRESTO_SNAPSHOT_VERSION} -f presto-base/Dockerfile-dev -t lewuathe/presto-base:${PRESTO_SNAPSHOT_VERSION} presto-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,19 +2,19 @@ version: '3'
 
 services:
   coordinator:
-    image: lewuathe/presto-coordinator:307-SNAPSHOT
+    image: "lewuathe/presto-coordinator:${PRESTO_VERSION}"
     ports:
       - "8080:8080"
     container_name: "coordinator"
     command: coordinator
   worker0:
-    image: lewuathe/presto-worker:307-SNAPSHOT
+    image: "lewuathe/presto-worker:${PRESTO_VERSION}"
     container_name: "worker0"
     ports:
       - "8081:8081"
     command: worker0
   worker1:
-    image: lewuathe/presto-worker:307-SNAPSHOT
+    image: "lewuathe/presto-worker:${PRESTO_VERSION}"
     container_name: "worker1"
     ports:
       - "8082:8081"


### PR DESCRIPTION
Before:
```
juan@desktop:~/opensource/docker-presto-cluster$ make run
docker-compose up -d
Creating network "dockerprestocluster_default" with the default driver
Pulling worker1 (lewuathe/presto-worker:307-SNAPSHOT)...
ERROR: manifest for lewuathe/presto-worker:307-SNAPSHOT not found
Makefile:23: recipe for target 'run' failed
make: *** [run] Error 1
```

After:
```
juan@desktop:~/opensource/docker-presto-cluster$ make run
PRESTO_VERSION=311 docker-compose up -d
Creating network "dockerprestocluster_default" with the default driver
Creating worker1 ... 
Creating coordinator ... 
Creating worker0 ... 
Creating coordinator
Creating worker1
Creating worker1 ... done
echo "Please check http://localhost:8080"
Please check http://localhost:8080

juan@desktop:~/opensource/docker-presto-cluster$ make down
PRESTO_VERSION=311 docker-compose down
Stopping worker0     ... done
Stopping coordinator ... done
Stopping worker1     ... done
Removing worker0     ... done
Removing coordinator ... done
Removing worker1     ... done
Removing network dockerprestocluster_default
```